### PR TITLE
Add example environment files and setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # jiralike2
-jiralike2
+
+## Setup
+
+### Backend
+
+Copy the example environment file and configure your database values:
+
+```bash
+cd backend
+cp .env.example .env
+# update DB_DATABASE and other settings as needed
+```
+
+### Frontend
+
+Copy the example environment file and configure the API endpoint:
+
+```bash
+cd frontend
+cp .env.example .env
+# set VITE_API_URL to your backend URL
+```

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,9 +21,9 @@ LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug
 
 DB_CONNECTION=sqlite
+DB_DATABASE=./database/database.sqlite
 # DB_HOST=127.0.0.1
 # DB_PORT=3306
-# DB_DATABASE=laravel
 # DB_USERNAME=root
 # DB_PASSWORD=
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -7,6 +7,15 @@
 <a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/l/laravel/framework" alt="License"></a>
 </p>
 
+## Setup
+
+Copy the example environment file and configure your database values:
+
+```bash
+cp .env.example .env
+# set DB_DATABASE and other credentials
+```
+
 ## About Laravel
 
 Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel takes the pain out of development by easing common tasks used in many web projects, such as:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+VITE_API_URL=http://localhost:8000
+

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,6 +2,15 @@
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
+## Setup
+
+Copy the example environment file and configure the API endpoint:
+
+```bash
+cp .env.example .env
+# set VITE_API_URL to your backend URL
+```
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh


### PR DESCRIPTION
## Summary
- include database path in backend `.env.example`
- add frontend `.env.example` with `VITE_API_URL`
- document `.env` setup steps for backend and frontend

## Testing
- `cd backend && phpunit` *(fails: command not found)*
- `cd frontend && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5aec9c970832c9ed93149dff830e1